### PR TITLE
Use integer comparison instead

### DIFF
--- a/templates/dsc-cassandra-env.sh.j2
+++ b/templates/dsc-cassandra-env.sh.j2
@@ -99,7 +99,7 @@ if [ "$JVM_VERSION" \< "1.7" ] ; then
     exit 1;
 fi
 
-if [ "$JVM_VERSION" \< "1.8" ] && [ "$JVM_PATCH_VERSION" \< "25" ] ; then
+if [ "$JVM_VERSION" \< "1.8" ] && [ "$JVM_PATCH_VERSION" -lt 25 ] ; then
     echo "Cassandra 2.0 and later require Java 7u25 or later."
     exit 1;
 fi


### PR DESCRIPTION
Cassandra with Java version later than 7u101 doesn't run because string "101" is less than string "25"
Based on the issue: https://issues.apache.org/jira/browse/CASSANDRA-11716

Changes taken from: https://github.com/apache/cassandra/blob/cassandra-2.2/conf/cassandra-env.sh
