### PR TITLE
Changed yum to package

### DIFF
--- a/tasks/cassandra-ddc.yml
+++ b/tasks/cassandra-ddc.yml
@@ -23,7 +23,9 @@
   when: ansible_os_family|lower == 'redhat'
 
 - name: Install datastax distribution for apache cassandra | RedHat
-  yum: name="datastax-ddc-{{ cassandra_version }}" state=present
+  package:
+    name: "datastax-ddc-{{ cassandra_version }}" 
+  state: present
   when: ansible_os_family|lower == 'redhat'
   register: rpm_install
 

--- a/tasks/cassandra-dsc.yml
+++ b/tasks/cassandra-dsc.yml
@@ -30,12 +30,16 @@
   when: ansible_os_family|lower == 'redhat'
 
 - name: Install cassandra | RedHat
-  yum: name="cassandra{{ cassandra_dsc_pkg_suffix }}-{{ cassandra_version }}" state=present
+  package:
+    name: "cassandra{{ cassandra_dsc_pkg_suffix }}-{{ cassandra_version }}"
+    state: present
   when: ansible_os_family|lower == 'redhat'
   register: rpm_install
 
 - name: Install cassandra datastax community package | RedHat
-  yum: name="dsc{{ cassandra_dsc_pkg_suffix }}-{{ cassandra_dsc_version }}" state=present
+  package:
+    name: "dsc{{ cassandra_dsc_pkg_suffix }}-{{ cassandra_dsc_version }}"
+    state: present
   when: ansible_os_family|lower == 'redhat'
   register: rpm_install
 


### PR DESCRIPTION
Installing on Fedora26 fails because yum is used instead of dnf and an error is raised.
`Msg: "ansible" "Failure talking to yum: Cannot retrieve metalink for repository: fedora. Please verify its path and try again".`

This was not an issue in previous versions.
The fix is to use the more generic package, which uses dnf instead of yum.